### PR TITLE
Fix setting doc.bod.style.background (requires int, not float)

### DIFF
--- a/src/js/extendscript.tsx
+++ b/src/js/extendscript.tsx
@@ -27,8 +27,8 @@ if (inCEPEnvironment()) {
   if (host) {
     const skin = host.appSkinInfo;
     const bgColor = skin.panelBackgroundColor.color as RGBColor;
-    document.body.style.background = `rgb(${bgColor.red}, ${bgColor.green}, ${
-      bgColor.blue
+    document.body.style.background = `rgb(${parseInt(bgColor.red)}, ${parseInt(bgColor.green)}, ${
+      parseInt(bgColor.blue)
     })`;
   }
 }


### PR DESCRIPTION
Using `document.body.style.background ` with `rgb` requires that the rgb values are int, not float; see https://www.w3schools.com/html/html_colors.asp

Found that the colour wasn't setting until they were parsed as int, or rounded.