### PR TITLE
Removes reference to missing manifest

### DIFF
--- a/src/js/extendscript.tsx
+++ b/src/js/extendscript.tsx
@@ -20,8 +20,13 @@ if (inCEPEnvironment()) {
 
   logger.info("start", extensionPath);
 
-  const manifest = fs.readJsonSync(path.join(extensionPath, "manifest.json"));
-  loadExtendscript(manifest["index.jsx.ts"]);
+  // NOTE This references the compiled file, so it’s necessary to
+  //      use the `.jsx.js` extension, instead of `.jsx.ts`.
+  //      Alternatively, install a plugin that adds a manifest
+  //      file, like npm.im/parcel-plugin-bundle-manifest
+  // const manifest = fs.readJsonSync(path.join(extensionPath, "parcel-manifest.json"));
+  // loadExtendscript(manifest["index.jsx.ts"]);
+  loadExtendscript("index.jsx.js");
 
   const host = getHostEnvironment();
   if (host) {


### PR DESCRIPTION
This PR fixes https://github.com/fusepilot/parcel-plugin-cep/issues/18

I know this overlaps with what was started in #4, but it looks like [parcel-plugin-bundle-manifest](https://npm.im/parcel-plugin-bundle-manifest) might not be getting updates anymore, and this is one way of solving the manifest problem without a dependency. If you prefer the `parcel-manifest.json` approach, I can open PR for that instead.

Otherwise, that’s documented in the comment. It’s the same manifest code from before with the filename changed to `parcel-manifest.json`. Thanks!